### PR TITLE
Various bugfixes for the gtfsToTimetableApi example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GTFS-examples
 
-Here you can find scripts written in Python and PHP, as an example on how you can use GTFS, and what's possible with it. 
+Here you can find scripts written in Python and PHP, as an example on how you can use GTFS, and what's possible with it.
 
 ## Contributing
 
@@ -10,6 +10,6 @@ If you would like to see a new feature added, you can also create a feature requ
 ## Help
 
 If you're stuck with a question, feel free to ask help through the Issue tracker.
-- Need help with API keys? Please read [www.trafiklab.se/api-nycklar](https://www.trafiklab.se/api-nycklar) first.
+- Need help with API keys? Please read [Getting Started](https://www.trafiklab.se/docs/getting-started/using-trafiklab) first.
 - Do you want to check the current systems status? Service disruptions
  are published on the [Trafiklab homepage](https://www.trafiklab.se/)

--- a/python/README.md
+++ b/python/README.md
@@ -25,6 +25,6 @@ see a new feature added, you can also create a feature request by creating an is
 
 If you're stuck with a question, feel free to ask help through the Issue tracker.
 
-- Need help with API keys? Please read [www.trafiklab.se/api-nycklar](https://www.trafiklab.se/api-nycklar) first.
+- Need help with API keys? Please read [Getting Started](https://www.trafiklab.se/docs/getting-started/using-trafiklab) first.
 - Do you want to check the current systems status? Service disruptions are published on
   the [Trafiklab homepage](https://www.trafiklab.se/)

--- a/python/gtfsToTimetableApi/GtfsTimeTable.py
+++ b/python/gtfsToTimetableApi/GtfsTimeTable.py
@@ -350,7 +350,7 @@ if __name__ == '__main__':
     required.add_argument("--vehicle-positions",
                           help="the url to the vehiclepositions.pb file. Include an API key if the realtime feed requires this.",
                           dest="vehicle_positions", required=True)
-    required.add_argument("--stop-id", help="the id of the stop to create a timetable for", dest="stop-id",
+    required.add_argument("--stop-id", help="the id of the stop to create a timetable for", dest="stop_id",
                           required=True)
     args = parser.parse_args()
 
@@ -362,5 +362,5 @@ if __name__ == '__main__':
     # will be offset by the reduced startup time.
     query_engine = TimeTableQueryEngine(gtfs_path, realtime_data_fetcher, reduce_memory_usage=True)
     # Run a sample query and print the result
-    result = query_engine.create_departures_timetable('9021012080000000')
+    result = query_engine.create_departures_timetable(args.stop_id)
     print(result)

--- a/python/gtfsToTimetableApi/GtfsTimeTable.py
+++ b/python/gtfsToTimetableApi/GtfsTimeTable.py
@@ -72,7 +72,7 @@ class GtfsArchiveFetcher:
         if is_outdated:
             logging.info("GTFS archive is older than 1 day")
         else:
-            logging.info("GTFS archive is less than 1 day old")
+            logging.debug("GTFS archive is less than 1 day old") # Since we check this on every call loglevel is set to DEBUG when the archive is up to date
         return is_outdated
 
 

--- a/python/gtfsToTimetableApi/TimeTableApi.py
+++ b/python/gtfsToTimetableApi/TimeTableApi.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import logging
 import sys
+from datetime import datetime, timedelta
 
 import flask
 
@@ -28,7 +29,9 @@ app = flask.Flask(__name__)
 
 @app.route('/departures/<stop_id>', methods=['GET'])
 def departures(stop_id):
-    resp = flask.Response(json.dumps(query_engine.create_departures_timetable(stop_id)))
+    window_start =  datetime.now() - timedelta(minutes=10)
+    window_end = datetime.now() + timedelta(hours=2)
+    resp = flask.Response(json.dumps(query_engine.create_departures_timetable(stop_id, window_start, window_end)))
     resp.headers['Content-encoding'] = 'UTF-8'
     resp.headers['Content-type'] = 'Application/json'
     return resp

--- a/python/gtfsToTimetableApi/TimeTableApi.py
+++ b/python/gtfsToTimetableApi/TimeTableApi.py
@@ -29,6 +29,7 @@ app = flask.Flask(__name__)
 
 @app.route('/departures/<stop_id>', methods=['GET'])
 def departures(stop_id):
+    gtfs_path = GtfsArchiveFetcher.fetch_and_extract(args.gtfs_url, "gtfs/")
     window_start =  datetime.now() - timedelta(minutes=10)
     window_end = datetime.now() + timedelta(hours=2)
     resp = flask.Response(json.dumps(query_engine.create_departures_timetable(stop_id, window_start, window_end)))
@@ -39,6 +40,7 @@ def departures(stop_id):
 
 @app.route('/stops/', methods=['GET'])
 def stops():
+    gtfs_path = GtfsArchiveFetcher.fetch_and_extract(args.gtfs_url, "gtfs/")
     resp = flask.Response(json.dumps(query_engine.list_queryable_stops()))
     resp.headers['Content-encoding'] = 'UTF-8'
     resp.headers['Content-type'] = 'Application/json'

--- a/python/gtfsToTimetableApi/requirements.txt
+++ b/python/gtfsToTimetableApi/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
-gtfs-realtime-bindings==0.0.7
-urllib3==1.26.5
+Flask==3.0.3
+gtfs-realtime-bindings==1.0.0
+urllib3==2.2.2
 requests==2.31.0


### PR DESCRIPTION
* Update README with valid links to how API-keys are created
* Update requirements.txt to allow for more modern versions of libraries needed. I have tested them and they work fine.
* Add window start and end to the query_engine calls since default arguments only evaluate when the function is defined which previously meant that the departure window was static.
* The static time-table files were only loaded on application start instead of every 24 hours as intended. They are now checked on ever end-point call and if expired, they will be updated. This means a few milliseconds additional delay to API-calls but should not be noticeable.
* if GtfsTimeTable.py is run directly, it didn't use the command-line provided stop_id. This is now fixed.